### PR TITLE
Clear image buffer before saving with quality

### DIFF
--- a/InstaxBLE.py
+++ b/InstaxBLE.py
@@ -465,6 +465,7 @@ class InstaxBLE:
 
         def save_img_with_quality(quality):
             img_buffer.seek(0)
+            img_buffer.truncate(0)
             img.save(img_buffer, format='JPEG', quality=quality)
             return img_buffer.tell() / 1024
 


### PR DESCRIPTION
In the `save_img_with_quality` function, the image buffer doesn't clear existing bytes before saving new image. If a new JPEG is smaller than an earlier one, leftover bytes remain at the end. It is also mentioned in [this issue](https://github.com/javl/InstaxBLE/issues/18#issuecomment-2166659723).

### Full reproduction steps:
1. Uncomment `self.log(f"len of imagedata: {len(imgData)}")` on line 382
2. Uncomment `self.log(f"current output quality: {current_quality}, current size: {output_size_kb}")` on line 480
3. Run the file with a large image with verbose (I used mini link1 to print a [dummy 200kb jpg](https://github.com/user-attachments/assets/1dfa30eb-3a2a-4397-9d38-1a3ea730916b))

### Console log
```
...
printing image "dummy_200kb.jpg"
current output quality: 75, current size: 270.697265625
current output quality: 37, current size: 170.5224609375
current output quality: 18, current size: 87.4423828125
current output quality: 27, current size: 95.9736328125
Saved img with quality of 27
len of imagedata: 277194
...
```

The len of imagedata doesn't match the size of the image with current quality. 

### Solution
Add a `img_buffer.truncate(0)` after `img_buffer.seek(0)` to clear the buffer before saving image with new quality.

### Console log after the fix
```
...
printing image "dummy_200kb.jpg"
current output quality: 75, current size: 270.697265625
current output quality: 37, current size: 170.5224609375
current output quality: 18, current size: 87.4423828125
current output quality: 27, current size: 95.9736328125
Saved img with quality of 27
len of imagedata: 98277
...
```

The len of imagedata now match the size of the image with current quality. 

